### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/alexandergaldones/7ee27ec1-3a02-49ac-8164-714663c2adee/9e0d5369-0577-4564-b633-806d74fd3a30/_apis/work/boardbadge/441e1a97-389e-49ea-ab66-669b1d2e9506)](https://dev.azure.com/alexandergaldones/7ee27ec1-3a02-49ac-8164-714663c2adee/_boards/board/t/9e0d5369-0577-4564-b633-806d74fd3a30/Microsoft.RequirementCategory)
 # xandergaldones.github.io
 My Github Page repository


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/alexandergaldones/7ee27ec1-3a02-49ac-8164-714663c2adee/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.